### PR TITLE
Fix some CM 11 button issues

### DIFF
--- a/kyleproxx-common-vendor-blobs.mk
+++ b/kyleproxx-common-vendor-blobs.mk
@@ -36,9 +36,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys.kl:/system/usr/keylayout/gpio-keys.kl \
     $(LOCAL_PATH)/proprietary/usr/keylayout/samsung-keypad.kl:/system/usr/keylayout/samsung-keypad.kl
 endif
-endif
-
-ifndef PRODUCT_VERSION_MAJOR
+else
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_keypad_v2.kl:/system/usr/keylayout/bcm_keypad_v2.kl \
     $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys.kl:/system/usr/keylayout/gpio-keys.kl \

--- a/kyleproxx-common-vendor-blobs.mk
+++ b/kyleproxx-common-vendor-blobs.mk
@@ -24,6 +24,27 @@ else
         $(LOCAL_PATH)/proprietary/lib/libril_KYLEPRO.so:/system/lib/libril.so
 endif
 
+ifdef PRODUCT_VERSION_MAJOR
+ifeq ($(PRODUCT_VERSION_MAJOR),11)
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_keypad_v2-cm11.kl:/system/usr/keylayout/bcm_keypad_v2.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys-cm11.kl:/system/usr/keylayout/gpio-keys.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/samsung-keypad-cm11.kl:/system/usr/keylayout/samsung-keypad.kl
+else
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_keypad_v2.kl:/system/usr/keylayout/bcm_keypad_v2.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys.kl:/system/usr/keylayout/gpio-keys.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/samsung-keypad.kl:/system/usr/keylayout/samsung-keypad.kl
+endif
+endif
+
+ifndef PRODUCT_VERSION_MAJOR
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_keypad_v2.kl:/system/usr/keylayout/bcm_keypad_v2.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys.kl:/system/usr/keylayout/gpio-keys.kl \
+    $(LOCAL_PATH)/proprietary/usr/keylayout/samsung-keypad.kl:/system/usr/keylayout/samsung-keypad.kl
+endif
+
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/proprietary/bin/BCM4330B1_002.001.003.0967.1173.hcd:/system/bin/BCM4330B1_002.001.003.0967.1173.hcd \
     $(LOCAL_PATH)/proprietary/bin/bkmgrd:/system/bin/bkmgrd \
@@ -189,7 +210,4 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/proprietary/usr/idc/Vendor_0001_Product_0001_Version_0100.idc:/system/usr/idc/Vendor_0001_Product_0001_Version_0100.idc \
     $(LOCAL_PATH)/proprietary/usr/keychars/bcm_keypad_v2.kcm:/system/usr/keychars/bcm_keypad_v2.kcm \
     $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_headset.kl:/system/usr/keylayout/bcm_headset.kl \
-    $(LOCAL_PATH)/proprietary/usr/keylayout/bcm_keypad_v2.kl:/system/usr/keylayout/bcm_keypad_v2.kl \
-    $(LOCAL_PATH)/proprietary/usr/keylayout/gpio-keys.kl:/system/usr/keylayout/gpio-keys.kl \
-    $(LOCAL_PATH)/proprietary/usr/keylayout/samsung-keypad.kl:/system/usr/keylayout/samsung-keypad.kl \
     $(LOCAL_PATH)/proprietary/usr/share/alsa/alsa.conf:/system/usr/share/alsa/alsa.conf

--- a/proprietary/usr/keylayout/bcm_keypad_v2-cm11.kl
+++ b/proprietary/usr/keylayout/bcm_keypad_v2-cm11.kl
@@ -1,0 +1,85 @@
+key 399   GRAVE
+key 2     1
+key 3     2
+key 4     3
+key 5     4
+key 6     5
+key 7     6
+key 8     7
+key 9     8
+key 10    9
+key 11    0
+key 158   BACK
+key 139   MENU              
+key 127   SEARCH
+key 217   RECENTAPPS
+key 228   POUND
+key 227   STAR
+key 352   DPAD_CENTER       
+key 108   DPAD_DOWN
+key 103   DPAD_UP
+key 102   HOME              WAKE
+key 105   DPAD_LEFT
+key 106   DPAD_RIGHT
+key 115   VOLUME_UP         
+key 114   VOLUME_DOWN       
+key 116   POWER             WAKE
+key 212   CAMERA
+
+key 16    Q
+key 17    W
+key 18    E
+key 19    R
+key 20    T
+key 21    Y
+key 22    U
+key 23    I
+key 24    O
+key 25    P
+key 26    LEFT_BRACKET
+key 27    RIGHT_BRACKET
+key 43    BACKSLASH
+
+key 30    A
+key 31    S
+key 32    D
+key 33    F
+key 34    G
+key 35    H
+key 36    J
+key 37    K
+key 38    L
+key 39    SEMICOLON
+key 40    APOSTROPHE
+key 14    DEL
+        
+key 44    Z
+key 45    X
+key 46    C
+key 47    V
+key 48    B
+key 49    N
+key 50    M
+key 51    COMMA
+key 52    PERIOD
+key 53    SLASH
+key 28    ENTER
+        
+key 56    ALT_LEFT
+key 100   ALT_RIGHT
+key 42    SHIFT_LEFT
+key 54    SHIFT_RIGHT
+key 15    TAB
+key 57    SPACE
+key 150   EXPLORER
+key 155   CUST2        
+key 442   CHATON 
+key 373   SYM
+key 12    MINUS
+key 13    EQUALS
+key 215   AT
+key 207   MUSIC 
+
+# On an AT keyboard: ESC, F10
+key 1     BACK              WAKE_DROPPED
+key 68    MENU              WAKE_DROPPED

--- a/proprietary/usr/keylayout/gpio-keys-cm11.kl
+++ b/proprietary/usr/keylayout/gpio-keys-cm11.kl
@@ -1,0 +1,9 @@
+key 115   VOLUME_UP         WAKE
+key 114   VOLUME_DOWN       WAKE
+key 116   POWER             WAKE
+key 102   HOME              WAKE
+key 105   DPAD_LEFT
+key 106   DPAD_RIGHT
+key 103   DPAD_UP
+key 108   DPAD_DOWN
+key 232   DPAD_CENTER

--- a/proprietary/usr/keylayout/samsung-keypad-cm11.kl
+++ b/proprietary/usr/keylayout/samsung-keypad-cm11.kl
@@ -1,0 +1,91 @@
+key 399   GRAVE
+key 2     1
+key 3     2
+key 4     3
+key 5     4
+key 6     5
+key 7     6
+key 8     7
+key 9     8
+key 10    9
+key 11    0
+key 158   BACK              WAKE_DROPPED
+key 230   SOFT_RIGHT        WAKE
+key 60    SOFT_RIGHT        WAKE
+key 107   ENDCALL           WAKE_DROPPED
+key 62    ENDCALL           WAKE_DROPPED
+key 229   MENU              WAKE_DROPPED
+key 139   MENU              WAKE_DROPPED
+key 59    MENU              WAKE_DROPPED
+key 127   SEARCH            WAKE_DROPPED
+key 217   SEARCH            WAKE_DROPPED
+key 228   POUND
+key 227   STAR
+key 231   CALL              WAKE_DROPPED
+key 61    CALL              WAKE_DROPPED
+key 232   DPAD_CENTER       WAKE_DROPPED
+key 108   DPAD_DOWN         WAKE_DROPPED
+key 103   DPAD_UP           WAKE_DROPPED
+key 102   HOME              WAKE
+key 105   DPAD_LEFT         WAKE_DROPPED
+key 106   DPAD_RIGHT        WAKE_DROPPED
+key 115   VOLUME_UP         WAKE
+key 114   VOLUME_DOWN       WAKE
+key 116   POWER             WAKE
+key 212   CAMERA
+
+key 16    Q
+key 17    W
+key 18    E
+key 19    R
+key 20    T
+key 21    Y
+key 22    U
+key 23    I
+key 24    O
+key 25    P
+key 26    LEFT_BRACKET
+key 27    RIGHT_BRACKET
+key 43    BACKSLASH
+
+key 30    A
+key 31    S
+key 32    D
+key 33    F
+key 34    G
+key 35    H
+key 36    J
+key 37    K
+key 38    L
+key 39    SEMICOLON
+key 40    APOSTROPHE
+key 14    DEL
+        
+key 44    Z
+key 45    X
+key 46    C
+key 47    V
+key 48    B
+key 49    N
+key 50    M
+key 51    COMMA
+key 52    PERIOD
+key 53    SLASH
+key 28    ENTER
+        
+key 56    ALT_LEFT
+key 100   ALT_RIGHT
+key 42    SHIFT_LEFT
+key 54    SHIFT_RIGHT
+key 15    TAB
+key 57    SPACE
+key 150   EXPLORER
+key 155   ENVELOPE        
+
+key 12    MINUS
+key 13    EQUALS
+key 215   AT
+
+# On an AT keyboard: ESC, F10
+key 1     BACK              WAKE_DROPPED
+key 68    MENU              WAKE_DROPPED


### PR DESCRIPTION
The "Update keylayouts for AOSP" commit broke Home button wakeup (at least on CM 11), so this commit adds a check that prevents using "AOSP" keylayouts if CM 11 is detected and allows the use of "AOSP" keylayouts if CM 11 isn't detected
